### PR TITLE
[RAC-1155] Shift sequences on the PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ _testmain.go
 /testfixtures
 /dist
 /tmp
+
+# JetBrains
+*.iml
+.idea

--- a/testfixtures.go
+++ b/testfixtures.go
@@ -207,6 +207,19 @@ func ResetSequencesTo(value int64) func(*Loader) error {
 	}
 }
 
+// ShiftSequencesTo sets the value the sequences will be shifted to.
+func ShiftSequencesTo(step int64) func(*Loader) error {
+	return func(l *Loader) error {
+		switch helper := l.helper.(type) {
+		case *postgreSQL:
+			helper.shiftSequencesTo = step
+		default:
+			return fmt.Errorf("testfixtures: ResetSequencesTo is only valid for PostgreSQL databases")
+		}
+		return nil
+	}
+}
+
 // DangerousSkipTestDatabaseCheck will make Loader not check if the database
 // name contains "test". Use with caution!
 func DangerousSkipTestDatabaseCheck() func(*Loader) error {
@@ -639,9 +652,7 @@ func (l *Loader) fixturesFromPaths(paths ...string) ([]*fixtureFile, error) {
 }
 
 func (l *Loader) fixturesFromFilesMultiTables(fileNames ...string) ([]*fixtureFile, error) {
-	var (
-		fixtureFiles = make([]*fixtureFile, 0, len(fileNames))
-	)
+	fixtureFiles := make([]*fixtureFile, 0, len(fileNames))
 
 	for _, f := range fileNames {
 		var (


### PR DESCRIPTION
## What is this PR?

- Fixture 로드시에 sequence를 이동시킬 수 있는 옵션을 추가
- entgql의 [Universal ID](https://entgo.io/docs/migrate/#universal-ids)를 활성화한 경우 테이블마다 일정한 대역폭을 가지도록 sequence가 생성됨.
- 픽스처 사용시 특정한 숫자로 시퀀스를 초기화 하는 `ResetSequenceTo` 옵션을 사용 할 수 없음.

이를 해결하기 위해 `ShiftSequenceTo` 옵션을 추가
- 픽스처 로드시마다 시퀀스를 초기화하며 초기값은 마지막으로 사용된 시퀀스에서 일정한 값을 증가시킴
- 얼마나 증가시킬 지는 `step` 파라미터로 지정.
